### PR TITLE
Fix fetching deadlock when connection issues occur

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-FROM golang:1.17 AS build
+FROM golang:1.18-rc AS build
 
 RUN mkdir -p /src/tjts
 WORKDIR /src/tjts

--- a/fetcher.go
+++ b/fetcher.go
@@ -82,6 +82,12 @@ func (f *fetcher) Run() error {
 			// set the next fetch for when ~75% of this fetch is up. that should
 			// give us time to fetch/retry without being aggressive.
 			rsd := time.Duration(float64(td) * 0.75)
+			if rsd == 0 {
+				// we probably downloaded no chunks. Cannot reset a ticker to 0
+				// and probably want to wait before retrying anyway, so reset to
+				// like 5s.
+				rsd = 5 * time.Second
+			}
 			f.l.Debugf("Resetting ticker to interval %s", rsd)
 			f.ticker.Reset(rsd)
 		case <-f.stopC:

--- a/icy.go
+++ b/icy.go
@@ -232,9 +232,9 @@ func calculateIcySleep(streamStart time.Time, servedTime time.Duration) time.Dur
 	// the difference between how much we have served, vs. how much we should serve
 	servedDelta := servedTime - expectedServed
 
-	if servedDelta < 0 {
-		// can't negative sleep
-		return 0
+	if servedDelta <= 0 {
+		// closest thing to immediate
+		return 1 * time.Nanosecond
 	}
 	return servedDelta
 }

--- a/icy_test.go
+++ b/icy_test.go
@@ -20,13 +20,13 @@ func TestCalcSleep(t *testing.T) {
 			Name:       "Behind by 30 seconds",
 			StartTime:  now.Add(-1 * time.Minute),
 			ServedTime: 30 * time.Second,
-			WantSleep:  0,
+			WantSleep:  1 * time.Nanosecond,
 		},
 		{
 			Name:       "On time",
 			StartTime:  now.Add(-1 * time.Minute),
 			ServedTime: 1*time.Minute + 30*time.Second,
-			WantSleep:  0,
+			WantSleep:  1 * time.Nanosecond,
 		},
 		{
 			Name:       "40 seconds ahead",
@@ -44,7 +44,7 @@ func TestCalcSleep(t *testing.T) {
 			Name:       "Behind by 1 minute",
 			StartTime:  now.Add(-1 * time.Hour),
 			ServedTime: 1*time.Hour - 1*time.Minute - 30*time.Second,
-			WantSleep:  0,
+			WantSleep:  1 * time.Nanosecond,
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
When there's network issues (thanks vodafone), chunks can fail to fetch. When this
happens our calculation to reset the timer based on fetched data returns 0, which
deadlocks the ticker (https://github.com/golang/go/issues/49315). As this will panic
in future releases as well, reset the ticker to 5 seconds when this occurs. This should
stop hammering things when network issues occur too. Exponential backoff would be nice,
but y'know.

Also upgrade to go 1.18rc while here, because why not.

Fixes #5