### PR TITLE
Handle stream format changes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,11 +3,11 @@ dbPath: tmp/state.db
 streams:
   # - id: triplej
   #   name: Triple J
-  #   url: https://abcradiolivehls-lh.akamaihd.net/i/triplejnsw_1@327300/index_64_a-p.m3u8?sd=10&rebase=on
+  #   url: https://mediaserviceslive.akamaized.net/hls/live/2038308/triplejnsw/masterhq.m3u8
   #   baseTimezone: Australia/Sydney
   #   nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/triplej/now.json
   - id: doublej
     name: Double J
-    url: https://abcradiolivehls-lh.akamaihd.net/i/doublejnsw_1@327293/index_64_a-p.m3u8?sd=10&rebase=on
+    url: https://mediaserviceslive.akamaized.net/hls/live/2038315/doublejnsw/masterhq.m3u8
     baseTimezone: Australia/Sydney
     nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/doublej/now.json

--- a/config.yaml
+++ b/config.yaml
@@ -3,11 +3,11 @@ dbPath: tmp/state.db
 streams:
   # - id: triplej
   #   name: Triple J
-  #   url: https://mediaserviceslive.akamaized.net/hls/live/2038308/triplejnsw/masterhq.m3u8
+  #   url: https://mediaserviceslive.akamaized.net/hls/live/2038308/triplejnsw/master.m3u8
   #   baseTimezone: Australia/Sydney
   #   nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/triplej/now.json
   - id: doublej
     name: Double J
-    url: https://mediaserviceslive.akamaized.net/hls/live/2038315-b/doublejnsw/masterhq.m3u8
+    url: https://mediaserviceslive.akamaized.net/hls/live/2038315/doublejnsw/master.m3u8
     baseTimezone: Australia/Sydney
     nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/doublej/now.json

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,6 @@ streams:
   #   nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/triplej/now.json
   - id: doublej
     name: Double J
-    url: https://mediaserviceslive.akamaized.net/hls/live/2038315/doublejnsw/masterhq.m3u8
+    url: https://mediaserviceslive.akamaized.net/hls/live/2038315-b/doublejnsw/masterhq.m3u8
     baseTimezone: Australia/Sydney
     nowPlayingURL: https://music.abcradio.net.au/api/v1/plays/doublej/now.json

--- a/fetcher.go
+++ b/fetcher.go
@@ -137,14 +137,14 @@ func (f *fetcher) downloadSegment(s *m3u8.SegmentItem) error {
 		return nil
 	}
 
-	f.l.Debugf("downloading chunk %s", cn)
+	f.l.Debugf("downloading chunk %s from %s", cn, segmentURL.String())
 	r, err := f.hc.Get(segmentURL.String())
 	if err != nil {
 		return err
 	}
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("wanted 200 from %s, got: %d", f.url.String(), r.StatusCode)
+		return fmt.Errorf("wanted 200 from %s, got: %d", segmentURL.String(), r.StatusCode)
 	}
 
 	if err := f.cs.WriteChunk(context.TODO(), cn, s.Duration, r.Body); err != nil {

--- a/fetcher.go
+++ b/fetcher.go
@@ -129,6 +129,7 @@ func (f *fetcher) getPlaylist(u *url.URL) (*m3u8.Playlist, *url.URL, error) {
 		if best == nil {
 			return nil, nil, errors.New("can't find anything in the master playlist")
 		}
+		f.l.Debugf("%s is a master playlist, using entry with bandwidth %d", u.String(), best.Bandwidth)
 		// recurse to get the actual items we want
 		u, err := resolveSegmentURL(r.Request.URL, best.URI)
 		if err != nil {

--- a/fetcher.go
+++ b/fetcher.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +62,7 @@ func (f *fetcher) Run() error {
 			f.l.Debug("tick")
 
 			// we don't hard error in here, assume we will retry/recover
-			pl, err := f.getPlaylist()
+			pl, plurl, err := f.getPlaylist(f.url)
 			if err != nil {
 				fetchErrorCount.WithLabelValues(f.streamID).Inc()
 				f.l.WithError(err).Warn("getting playlist")
@@ -71,7 +72,7 @@ func (f *fetcher) Run() error {
 			var td time.Duration
 
 			for _, s := range pl.Segments() {
-				if err := f.downloadSegment(s); err != nil {
+				if err := f.downloadSegment(plurl, s); err != nil {
 					fetchErrorCount.WithLabelValues(f.streamID).Inc()
 					f.l.WithError(err).Warn("downloading segment")
 					continue
@@ -100,25 +101,47 @@ func (f *fetcher) Interrupt(_ error) {
 	f.stopC <- struct{}{}
 }
 
-func (f *fetcher) getPlaylist() (*m3u8.Playlist, error) {
-	r, err := f.hc.Get(f.url.String())
+func (f *fetcher) getPlaylist(u *url.URL) (*m3u8.Playlist, *url.URL, error) {
+	r, err := f.hc.Get(u.String())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("wanted 200 from %s, got: %d", f.url.String(), r.StatusCode)
+		return nil, nil, fmt.Errorf("wanted 200 from %s, got: %d", u.String(), r.StatusCode)
 	}
 
 	pl, err := m3u8.Read(r.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading playlist from %s: %v", f.url.String(), err)
+		return nil, nil, fmt.Errorf("reading playlist from %s: %v", u.String(), err)
 	}
-	return pl, nil
+
+	if pl.IsMaster() {
+		// master playlist links others...
+		var best *m3u8.PlaylistItem
+		for _, i := range pl.Items {
+			if i, ok := i.(*m3u8.PlaylistItem); ok {
+				if best == nil || i.Bandwidth > best.Bandwidth {
+					best = i
+				}
+			}
+		}
+		if best == nil {
+			return nil, nil, errors.New("can't find anything in the master playlist")
+		}
+		// recurse to get the actual items we want
+		u, err := resolveSegmentURL(r.Request.URL, best.URI)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving playlist url %s: %w", best.URI, err)
+		}
+		return f.getPlaylist(u)
+	}
+
+	return pl, r.Request.URL, nil
 }
 
-func (f *fetcher) downloadSegment(s *m3u8.SegmentItem) error {
-	segmentURL, err := f.resolveSegmentURL(s.Segment)
+func (f *fetcher) downloadSegment(playlistURL *url.URL, s *m3u8.SegmentItem) error {
+	segmentURL, err := resolveSegmentURL(playlistURL, s.Segment)
 	if err != nil {
 		return err
 	}
@@ -154,12 +177,12 @@ func (f *fetcher) downloadSegment(s *m3u8.SegmentItem) error {
 	return nil
 }
 
-func (f *fetcher) resolveSegmentURL(segment string) (*url.URL, error) {
+func resolveSegmentURL(playlistURL *url.URL, segment string) (*url.URL, error) {
 	segmentURL, err := url.Parse(segment)
 	if err != nil {
 		return nil, fmt.Errorf("parsing segment %s as URL: %w", segment, err)
 	}
-	return f.url.ResolveReference(segmentURL), nil
+	return playlistURL.ResolveReference(segmentURL), nil
 }
 
 func chunkNameFromURL(u string) (string, error) {

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestResolveSegmentURL(t *testing.T) {
+	u, err := url.Parse("https://server/stream/playlist.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := &fetcher{
+		url: u,
+	}
+
+	res, err := f.resolveSegmentURL("https://absolute/url.aac")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.String() != "https://absolute/url.aac" {
+		t.Errorf("should resolve to https://absolute/url.aac , got: %s", res.String())
+	}
+
+	res, err = f.resolveSegmentURL("file.aac")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.String() != "https://server/stream/file.aac" {
+		t.Errorf("should resolve to https://server/stream/file.aac , got: %s", res.String())
+	}
+}

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -11,11 +11,7 @@ func TestResolveSegmentURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := &fetcher{
-		url: u,
-	}
-
-	res, err := f.resolveSegmentURL("https://absolute/url.aac")
+	res, err := resolveSegmentURL(u, "https://absolute/url.aac")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +20,7 @@ func TestResolveSegmentURL(t *testing.T) {
 		t.Errorf("should resolve to https://absolute/url.aac , got: %s", res.String())
 	}
 
-	res, err = f.resolveSegmentURL("file.aac")
+	res, err = resolveSegmentURL(u, "file.aac")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/icy.go
+++ b/icy.go
@@ -129,7 +129,9 @@ func (i *icyServer) ServeIcecast(w http.ResponseWriter, r *http.Request) {
 			 * clean this up a bit to be better about content type management, and
 			 * structure in to not-big-if-else
 			 */
+			var rawAAC bool
 			if filepath.Ext(c.ChunkID) == ".aac" {
+				rawAAC = true
 				// this is a raw aac blob, just send it
 				if _, err := io.Copy(w, cr); err != nil {
 					serveEndpointErrorCount.WithLabelValues("icy", streamID).Inc()
@@ -227,7 +229,7 @@ func (i *icyServer) ServeIcecast(w http.ResponseWriter, r *http.Request) {
 			servedTime = servedTime + cd
 			s = c.Sequence + 1
 
-			l.Debugf("s: %d gotSeq %d streamStart %s servedTime %s calcSleep %s", s, c.Sequence, streamStart.String(), servedTime.String(), calculateIcySleep(streamStart, servedTime).String())
+			l.Debugf("s: %d rawAAC: %t gotSeq %d streamStart %s servedTime %s calcSleep %s", s, rawAAC, c.Sequence, streamStart.String(), servedTime.String(), calculateIcySleep(streamStart, servedTime).String())
 
 			// set the timer to the calculated sleep interval
 			nextRun.Reset(calculateIcySleep(streamStart, servedTime))

--- a/icy.go
+++ b/icy.go
@@ -130,7 +130,7 @@ func (i *icyServer) ServeIcecast(w http.ResponseWriter, r *http.Request) {
 			 * structure in to not-big-if-else
 			 */
 			if filepath.Ext(c.ChunkID) == ".aac" {
-				// this is a raw aac blob. send it and exit early
+				// this is a raw aac blob, just send it
 				if _, err := io.Copy(w, cr); err != nil {
 					serveEndpointErrorCount.WithLabelValues("icy", streamID).Inc()
 					l.WithError(err).Error("writing aac chunk to consumer")


### PR DESCRIPTION
Upstream changed the stream a bit, and things broke:

* Using a master playlist with multi-bandwidth
* using raw AAC segments

Update to handle the master playlist, choosing the highest bandwith by default. This is a good change, because it's a quality boost. Handle the raw AAC segments on the icy feed by just passing them through directly. Some fixes to handle relative content URLs too